### PR TITLE
refactor: refactor bad smell ToArrayCallWithZeroLengthArrayArgument

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/bamboo/BambooBuildPlanService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/bamboo/BambooBuildPlanService.java
@@ -202,9 +202,9 @@ public class BambooBuildPlanService {
 
                 // This conversion is required because the attributes are passed as varargs-parameter which is only possible
                 // for array collections
-                var defaultTasksArray = defaultTasks.toArray(new Task<?, ?>[defaultTasks.size()]);
-                var finalTasksArray = finalTasks.toArray(new Task<?, ?>[finalTasks.size()]);
-                var artifactsArray = artifacts.toArray(new Artifact[artifacts.size()]);
+                var defaultTasksArray = defaultTasks.toArray(new Task<?, ?>[0]);
+                var finalTasksArray = finalTasks.toArray(new Task<?, ?>[0]);
+                var artifactsArray = artifacts.toArray(new Artifact[0]);
 
                 // assign tasks and artifacts to job
                 defaultJob.tasks(defaultTasksArray);


### PR DESCRIPTION
# Repairing Code Style Issues
<!-- laughing-train-refactor -->
## ToArrayCallWithZeroLengthArrayArgument
The performance of the empty array version is the same, and sometimes even better, compared
to the pre-sized version. Also, passing a pre-sized array is dangerous for a concurrent or
synchronized collection as a data race is possible between the <code>size</code> and <code>toArray</code>
calls. This may result in extra <code>null</code>s at the end of the array if the collection was concurrently
shrunk during the operation.</p>
See https://shipilev.net/blog/2016/arrays-wisdom-ancients/ for more details.

<!-- fingerprint:2140800554 -->
<!-- fingerprint:-508119662 -->
<!-- fingerprint:2077644305 -->
# Repairing Code Style Issues
* ToArrayCallWithZeroLengthArrayArgument (3)
